### PR TITLE
Removed type of script declaration because it's deprecated

### DIFF
--- a/FieldtypeVideo.module
+++ b/FieldtypeVideo.module
@@ -33,7 +33,7 @@ class FieldtypeVideo extends FieldtypeFile implements Module, ConfigurableModule
 
     protected static $configDefaults = array(
         // global
-        'player_scripts' => '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/2.20.1/mediaelement.min.js"></script>',
+        'player_scripts' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/2.20.1/mediaelement.min.js"></script>',
         'player_code' => '
         <video width="{width}" height="{height}" poster="{poster}" controls="controls" preload="none">
             <source type="video/mp4" src="{url}" />


### PR DESCRIPTION
Apparently when I validate it tells me:
![Screenshot 2020-10-14 at 14 20 34](https://user-images.githubusercontent.com/11830669/95987968-776c5080-0e28-11eb-8314-b6d0111a235c.png)

It's nothing major, but it bothered me, so I wanted to clean it up.